### PR TITLE
Update r-rmarkdown and its dependencies

### DIFF
--- a/packages/r-bslib/.SRCINFO
+++ b/packages/r-bslib/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-bslib
 	pkgdesc = Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'
-	pkgver = 0.4.2
+	pkgver = 0.5.0
 	pkgrel = 1
 	url = https://cran.r-project.org/package=bslib
 	arch = any
@@ -12,7 +12,7 @@ pkgbase = r-bslib
 	depends = r-jquerylib>=0.1.3
 	depends = r-rlang
 	depends = r-cachem
-	depends = r-memoise
+	depends = r-memoise>=2.0.1
 	depends = r-base64enc
 	depends = r-mime
 	optdepends = r-shiny
@@ -26,7 +26,7 @@ pkgbase = r-bslib
 	optdepends = r-magrittr
 	optdepends = r-fontawesome
 	optdepends = r-bsicons
-	source = https://cran.r-project.org/src/contrib/bslib_0.4.2.tar.gz
-	sha256sums = 9a40b7a1bbe409af273e1e940d921ab198ea576548f06f055f552f70ff822f19
+	source = https://cran.r-project.org/src/contrib/bslib_0.5.0.tar.gz
+	sha256sums = a2c6fbc62242806e10bb58c5d1ba04a6d3bf4e546bc53d7acf1b8eb1160bd115
 
 pkgname = r-bslib

--- a/packages/r-bslib/PKGBUILD
+++ b/packages/r-bslib/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Viktor Drobot (aka dviktor) linux776 [at] gmail [dot] com
 
 _cranname=bslib
-_cranver=0.4.2
+_cranver=0.5.0
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -9,10 +9,10 @@ pkgdesc="Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'"
 arch=(any)
 url="https://cran.r-project.org/package=${_cranname}"
 license=(MIT)
-depends=('r>=2.10' 'r-htmltools>=0.5.4' r-jsonlite 'r-sass>=0.4.0' 'r-jquerylib>=0.1.3' r-rlang r-cachem r-memoise r-base64enc r-mime)
+depends=('r>=2.10' 'r-htmltools>=0.5.4' r-jsonlite 'r-sass>=0.4.0' 'r-jquerylib>=0.1.3' r-rlang r-cachem 'r-memoise>=2.0.1' r-base64enc r-mime)
 optdepends=(r-shiny r-rmarkdown r-thematic r-knitr r-testthat r-withr r-rappdirs r-curl r-magrittr r-fontawesome r-bsicons)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('9a40b7a1bbe409af273e1e940d921ab198ea576548f06f055f552f70ff822f19')
+sha256sums=('a2c6fbc62242806e10bb58c5d1ba04a6d3bf4e546bc53d7acf1b8eb1160bd115')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-cachem/.SRCINFO
+++ b/packages/r-cachem/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-cachem
 	pkgdesc = Cache R Objects with Automatic Pruning
-	pkgver = 1.0.7
+	pkgver = 1.0.8
 	pkgrel = 1
 	url = https://cran.r-project.org/package=cachem
 	arch = i686
@@ -8,9 +8,9 @@ pkgbase = r-cachem
 	license = MIT
 	depends = r
 	depends = r-rlang
-	depends = r-fastmap
+	depends = r-fastmap>=1.1.1
 	optdepends = r-testthat
-	source = https://cran.r-project.org/src/contrib/cachem_1.0.7.tar.gz
-	sha256sums = 234fad2a947d1e1fb87d3fa92abf9197877772e31bc81ae5991ae69689b6320a
+	source = https://cran.r-project.org/src/contrib/cachem_1.0.8.tar.gz
+	sha256sums = ea9ca919fe615dce8770758ecc2fc88ac99074f66ff1cde3a0b95d40007f45c2
 
 pkgname = r-cachem

--- a/packages/r-cachem/PKGBUILD
+++ b/packages/r-cachem/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Viktor Drobot (aka dviktor) linux776 [at] gmail [dot] com
 
 _cranname=cachem
-_cranver=1.0.7
+_cranver=1.0.8
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -9,10 +9,10 @@ pkgdesc="Cache R Objects with Automatic Pruning"
 arch=(i686 x86_64)
 url="https://cran.r-project.org/package=${_cranname}"
 license=(MIT)
-depends=(r r-rlang r-fastmap)
+depends=(r r-rlang 'r-fastmap>=1.1.1')
 optdepends=(r-testthat)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('234fad2a947d1e1fb87d3fa92abf9197877772e31bc81ae5991ae69689b6320a')
+sha256sums=('ea9ca919fe615dce8770758ecc2fc88ac99074f66ff1cde3a0b95d40007f45c2')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-cli/.SRCINFO
+++ b/packages/r-cli/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-cli
 	pkgdesc = Helpers for Developing Command Line Interfaces
-	pkgver = 3.6.0
+	pkgver = 3.6.1
 	pkgrel = 1
 	url = https://cran.r-project.org/package=cli
 	arch = i686
@@ -26,7 +26,7 @@ pkgbase = r-cli
 	optdepends = r-tibble
 	optdepends = r-whoami
 	optdepends = r-withr
-	source = https://cran.r-project.org/src/contrib/cli_3.6.0.tar.gz
-	sha256sums = b6078131803043d53d4e670aa3a0506f614e0b40fda8e0102afd48a6188ab896
+	source = https://cran.r-project.org/src/contrib/cli_3.6.1.tar.gz
+	sha256sums = be3006cec7e67f9ae25e21b4658c4bec680038c2ef7467df5f14da3311a05e36
 
 pkgname = r-cli

--- a/packages/r-cli/PKGBUILD
+++ b/packages/r-cli/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Grey Christoforo <first name at last name dot net>
 
 _cranname=cli
-_cranver=3.6.0
+_cranver=3.6.1
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -13,7 +13,7 @@ license=(MIT)
 depends=('r>=3.4')
 optdepends=(r-callr r-covr r-crayon r-digest r-glue r-htmltools r-htmlwidgets r-knitr r-mockery r-processx r-ps r-rlang r-rmarkdown r-rprojroot r-rstudioapi r-testthat r-tibble r-whoami r-withr)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('b6078131803043d53d4e670aa3a0506f614e0b40fda8e0102afd48a6188ab896')
+sha256sums=('be3006cec7e67f9ae25e21b4658c4bec680038c2ef7467df5f14da3311a05e36')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-evaluate/.SRCINFO
+++ b/packages/r-evaluate/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-evaluate
 	pkgdesc = Parsing and Evaluation Tools that Provide More Details than the Default
-	pkgver = 0.20
+	pkgver = 0.21
 	pkgrel = 1
 	url = https://cran.r-project.org/package=evaluate
 	arch = any
@@ -9,7 +9,7 @@ pkgbase = r-evaluate
 	optdepends = r-covr
 	optdepends = r-ggplot2
 	optdepends = r-testthat
-	source = https://cran.r-project.org/src/contrib/evaluate_0.20.tar.gz
-	sha256sums = 35f5d9e85603600b58960923d591c5ca1115153febba7c612867d8b5598afff0
+	source = https://cran.r-project.org/src/contrib/evaluate_0.21.tar.gz
+	sha256sums = 3178c99cee8917d7d128806d064d4fecce7845ed07f42e759dcc0adda89c22b9
 
 pkgname = r-evaluate

--- a/packages/r-evaluate/PKGBUILD
+++ b/packages/r-evaluate/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Viktor Drobot (aka dviktor) linux776 [at] gmail [dot] com
 
 _cranname=evaluate
-_cranver=0.20
+_cranver=0.21
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -12,7 +12,7 @@ license=(MIT)
 depends=('r>=3.0.2')
 optdepends=(r-covr r-ggplot2 r-testthat)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('35f5d9e85603600b58960923d591c5ca1115153febba7c612867d8b5598afff0')
+sha256sums=('3178c99cee8917d7d128806d064d4fecce7845ed07f42e759dcc0adda89c22b9')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-fontawesome/.SRCINFO
+++ b/packages/r-fontawesome/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-fontawesome
 	pkgdesc = Easily Work with 'Font Awesome' Icons
-	pkgver = 0.5.0
+	pkgver = 0.5.1
 	pkgrel = 1
 	url = https://cran.r-project.org/package=fontawesome
 	arch = any
@@ -13,7 +13,7 @@ pkgbase = r-fontawesome
 	optdepends = r-knitr
 	optdepends = r-testthat
 	optdepends = r-rsvg
-	source = https://cran.r-project.org/src/contrib/fontawesome_0.5.0.tar.gz
-	sha256sums = 4117b417a33e82d626881d7059eb54e7534cba202e75dae7e27021cb3796e90b
+	source = https://cran.r-project.org/src/contrib/fontawesome_0.5.1.tar.gz
+	sha256sums = f4ebbbe2ee8d2e2c0342b72095cfe668bd9800ea6c4bf7180300544bde7e566c
 
 pkgname = r-fontawesome

--- a/packages/r-fontawesome/PKGBUILD
+++ b/packages/r-fontawesome/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Viktor Drobot (aka dviktor) linux776 [at] gmail [dot] com
 
 _cranname=fontawesome
-_cranver=0.5.0
+_cranver=0.5.1
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -12,7 +12,7 @@ license=(MIT)
 depends=('r>=3.3.0' 'r-rlang>=1.0.6' 'r-htmltools>=0.5.1.1')
 optdepends=(r-covr r-dplyr r-knitr r-testthat r-rsvg)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('4117b417a33e82d626881d7059eb54e7534cba202e75dae7e27021cb3796e90b')
+sha256sums=('f4ebbbe2ee8d2e2c0342b72095cfe668bd9800ea6c4bf7180300544bde7e566c')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-fs/.SRCINFO
+++ b/packages/r-fs/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-fs
 	pkgdesc = Cross-Platform File System Operations Based on 'libuv'
-	pkgver = 1.6.1
+	pkgver = 1.6.2
 	pkgrel = 1
 	url = https://cran.r-project.org/package=fs
 	arch = i686
@@ -18,7 +18,7 @@ pkgbase = r-fs
 	optdepends = r-tibble
 	optdepends = r-vctrs
 	optdepends = r-withr
-	source = https://cran.r-project.org/src/contrib/fs_1.6.1.tar.gz
-	sha256sums = faf1e421a2c270c60c0a30c74e1a48faad45b339163716102d77d64d23d76732
+	source = https://cran.r-project.org/src/contrib/fs_1.6.2.tar.gz
+	sha256sums = 548b7c0ed5ab26dc4fbd88707ae12987bcaef834dbc6de4e17d453846dc436b2
 
 pkgname = r-fs

--- a/packages/r-fs/PKGBUILD
+++ b/packages/r-fs/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Alex Branham <alex.branham@gmail.com>
 
 _cranname=fs
-_cranver=1.6.1
+_cranver=1.6.2
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -14,7 +14,7 @@ depends=('r>=3.4')
 makedepends=(make)
 optdepends=(r-covr r-crayon r-knitr r-pillar r-rmarkdown r-spelling r-testthat r-tibble r-vctrs r-withr)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('faf1e421a2c270c60c0a30c74e1a48faad45b339163716102d77d64d23d76732')
+sha256sums=('548b7c0ed5ab26dc4fbd88707ae12987bcaef834dbc6de4e17d453846dc436b2')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-htmltools/.SRCINFO
+++ b/packages/r-htmltools/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-htmltools
 	pkgdesc = Tools for HTML
-	pkgver = 0.5.4
+	pkgver = 0.5.5
 	pkgrel = 1
 	url = https://cran.r-project.org/package=htmltools
 	arch = i686
@@ -19,7 +19,7 @@ pkgbase = r-htmltools
 	optdepends = r-cairo
 	optdepends = r-ragg
 	optdepends = r-shiny
-	source = https://cran.r-project.org/src/contrib/htmltools_0.5.4.tar.gz
-	sha256sums = 008228a8690d39d8ae2716bc614e76337fdbe2bac4e96258c10245fdf24f327e
+	source = https://cran.r-project.org/src/contrib/htmltools_0.5.5.tar.gz
+	sha256sums = c8b23fab855a89c6ed0f6d6c7cad0ff9c5ae329c0bdb479940443ee752f26659
 
 pkgname = r-htmltools

--- a/packages/r-htmltools/PKGBUILD
+++ b/packages/r-htmltools/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Alex Branham <branham@utexas.edu>
 
 _cranname=htmltools
-_cranver=0.5.4
+_cranver=0.5.5
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -14,7 +14,7 @@ license=(GPL2 GPL3)
 depends=('r>=2.14.1' r-digest r-base64enc 'r-rlang>=0.4.10' 'r-fastmap>=1.1.0' r-ellipsis)
 optdepends=(r-markdown r-testthat r-withr r-cairo r-ragg r-shiny)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('008228a8690d39d8ae2716bc614e76337fdbe2bac4e96258c10245fdf24f327e')
+sha256sums=('c8b23fab855a89c6ed0f6d6c7cad0ff9c5ae329c0bdb479940443ee752f26659')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-jsonlite/.SRCINFO
+++ b/packages/r-jsonlite/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-jsonlite
 	pkgdesc = A Robust, High Performance JSON Parser and Generator for R
-	pkgver = 1.8.4
+	pkgver = 1.8.5
 	pkgrel = 1
 	url = https://cran.r-project.org/package=jsonlite
 	arch = i686
@@ -14,7 +14,7 @@ pkgbase = r-jsonlite
 	optdepends = r-rmarkdown
 	optdepends = r-r.rsp
 	optdepends = r-sf
-	source = https://cran.r-project.org/src/contrib/jsonlite_1.8.4.tar.gz
-	sha256sums = 79eaabe042226b0918aa828cc63d54fee8be67ae7c67f5e0d3010f468efb1278
+	source = https://cran.r-project.org/src/contrib/jsonlite_1.8.5.tar.gz
+	sha256sums = dc3cca4bdca1b6d6836c412760ea9656140683126c54cb89c3e42219dec4a3ad
 
 pkgname = r-jsonlite

--- a/packages/r-jsonlite/PKGBUILD
+++ b/packages/r-jsonlite/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Alex Branham <branham@utexas.edu>
 
 _cranname=jsonlite
-_cranver=1.8.4
+_cranver=1.8.5
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -15,7 +15,7 @@ license=(MIT)
 depends=(r)
 optdepends=(r-httr r-vctrs r-testthat r-knitr r-rmarkdown r-r.rsp r-sf)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('79eaabe042226b0918aa828cc63d54fee8be67ae7c67f5e0d3010f468efb1278')
+sha256sums=('dc3cca4bdca1b6d6836c412760ea9656140683126c54cb89c3e42219dec4a3ad')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-knitr/.SRCINFO
+++ b/packages/r-knitr/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-knitr
 	pkgdesc = A General-Purpose Package for Dynamic Report Generation in R
-	pkgver = 1.42
+	pkgver = 1.43
 	pkgrel = 1
 	url = https://cran.r-project.org/package=knitr
 	arch = any
@@ -10,7 +10,7 @@ pkgbase = r-knitr
 	depends = r-evaluate>=0.15
 	depends = r-highr
 	depends = r-yaml>=2.1.19
-	depends = r-xfun>=0.34
+	depends = r-xfun>=0.39
 	optdepends = r-markdown
 	optdepends = r-formatr
 	optdepends = r-testit
@@ -40,7 +40,7 @@ pkgbase = r-knitr
 	optdepends = r-targets
 	optdepends = pandoc: R Markdown v2 and reStructuredText support
 	optdepends = rst2pdf: rst2pdf() support
-	source = https://cran.r-project.org/src/contrib/knitr_1.42.tar.gz
-	sha256sums = 9344f1a0089e4da101def54aee38d7cfe3b2022d75c560141d8cc22ac65130f3
+	source = https://cran.r-project.org/src/contrib/knitr_1.43.tar.gz
+	sha256sums = 3d29baea8c349aaa9310879ceb9a9d51bcaec39827ad46d422c3793c8a4ed53c
 
 pkgname = r-knitr

--- a/packages/r-knitr/PKGBUILD
+++ b/packages/r-knitr/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Viktor Drobot (aka dviktor) linux776 [at] gmail [dot] com
 
 _cranname=knitr
-_cranver=1.42
+_cranver=1.43
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -9,10 +9,10 @@ pkgdesc="A General-Purpose Package for Dynamic Report Generation in R"
 arch=(any)
 url="https://cran.r-project.org/package=${_cranname}"
 license=(GPL2 GPL3)
-depends=('r>=3.3.0' 'r-evaluate>=0.15' r-highr 'r-yaml>=2.1.19' 'r-xfun>=0.34')
+depends=('r>=3.3.0' 'r-evaluate>=0.15' r-highr 'r-yaml>=2.1.19' 'r-xfun>=0.39')
 optdepends=(r-markdown r-formatr r-testit r-digest r-rgl r-rmarkdown r-htmlwidgets r-webshot r-tikzdevice r-tinytex r-reticulate r-juliacall r-magick r-png r-jpeg r-gifski r-xml2 r-httr r-dbi r-showtext r-tibble r-sass r-bslib r-ragg r-gridsvg r-styler r-targets 'pandoc: R Markdown v2 and reStructuredText support' 'rst2pdf: rst2pdf() support')
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('9344f1a0089e4da101def54aee38d7cfe3b2022d75c560141d8cc22ac65130f3')
+sha256sums=('3d29baea8c349aaa9310879ceb9a9d51bcaec39827ad46d422c3793c8a4ed53c')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-rlang/.SRCINFO
+++ b/packages/r-rlang/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-rlang
 	pkgdesc = Functions for Base Types and Core R and 'Tidyverse' Features
-	pkgver = 1.0.6
+	pkgver = 1.1.1
 	pkgrel = 1
 	url = https://cran.r-project.org/package=rlang
 	arch = i686
@@ -21,7 +21,7 @@ pkgbase = r-rlang
 	optdepends = r-usethis
 	optdepends = r-vctrs
 	optdepends = r-withr
-	source = https://cran.r-project.org/src/contrib/rlang_1.0.6.tar.gz
-	sha256sums = e6973d98a0ea301c0da1eeaa435e9e65d1c3f0b95ed68bdc2d6cb0c610166760
+	source = https://cran.r-project.org/src/contrib/rlang_1.1.1.tar.gz
+	sha256sums = 5e5ec9a7796977216c39d94b1e342e08f0681746657067ba30de11b8fa8ada99
 
 pkgname = r-rlang

--- a/packages/r-rlang/PKGBUILD
+++ b/packages/r-rlang/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Grey Christoforo <first name at last name dot net>
 
 _cranname=rlang
-_cranver=1.0.6
+_cranver=1.1.1
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -13,7 +13,7 @@ license=(MIT)
 depends=('r>=3.4.0')
 optdepends=(r-cli r-covr r-crayon r-fs r-glue r-knitr r-magrittr r-pillar r-rmarkdown r-testthat r-tibble r-usethis r-vctrs r-withr)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('e6973d98a0ea301c0da1eeaa435e9e65d1c3f0b95ed68bdc2d6cb0c610166760')
+sha256sums=('5e5ec9a7796977216c39d94b1e342e08f0681746657067ba30de11b8fa8ada99')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-rmarkdown/.SRCINFO
+++ b/packages/r-rmarkdown/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-rmarkdown
 	pkgdesc = Dynamic Documents for R
-	pkgver = 2.20
+	pkgver = 2.22
 	pkgrel = 2
 	url = https://cran.r-project.org/package=rmarkdown
 	arch = any
@@ -8,6 +8,7 @@ pkgbase = r-rmarkdown
 	depends = r>=3.0
 	depends = r-bslib>=0.2.5.1
 	depends = r-evaluate>=0.13
+	depends = r-fontawesome>=0.5.0
 	depends = r-htmltools>=0.5.1
 	depends = r-jquerylib
 	depends = r-jsonlite
@@ -30,7 +31,7 @@ pkgbase = r-rmarkdown
 	optdepends = r-tufte
 	optdepends = r-vctrs
 	optdepends = r-withr
-	source = https://cran.r-project.org/src/contrib/rmarkdown_2.20.tar.gz
-	sha256sums = d7f7059bfcb43e4b92432d69ba0e0c74ad10a20f153689262a3e848adb60159d
+	source = https://cran.r-project.org/src/contrib/rmarkdown_2.22.tar.gz
+	sha256sums = c6635519503e0fcdd518696d3ac96d8d28d9d4ecd9db0532c53426002f6387b8
 
 pkgname = r-rmarkdown

--- a/packages/r-rmarkdown/PKGBUILD
+++ b/packages/r-rmarkdown/PKGBUILD
@@ -6,7 +6,7 @@
 # Contributor: Alex Branham <branham@utexas.edu>
 
 _cranname=rmarkdown
-_cranver=2.20
+_cranver=2.22
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=2
@@ -14,10 +14,10 @@ pkgdesc="Dynamic Documents for R"
 arch=(any)
 url="https://cran.r-project.org/package=${_cranname}"
 license=(GPL3)
-depends=('r>=3.0' 'r-bslib>=0.2.5.1' 'r-evaluate>=0.13' 'r-htmltools>=0.5.1' r-jquerylib r-jsonlite 'r-knitr>=1.22' 'r-stringr>=1.2.0' 'r-tinytex>=0.31' 'r-xfun>=0.36' 'r-yaml>=2.1.19' pandoc)
+depends=('r>=3.0' 'r-bslib>=0.2.5.1' 'r-evaluate>=0.13' 'r-fontawesome>=0.5.0' 'r-htmltools>=0.5.1' r-jquerylib r-jsonlite 'r-knitr>=1.22' 'r-stringr>=1.2.0' 'r-tinytex>=0.31' 'r-xfun>=0.36' 'r-yaml>=2.1.19' pandoc)
 optdepends=(r-digest r-dygraphs r-fs r-rsconnect r-downlit r-katex r-sass r-shiny r-testthat r-tibble r-tufte r-vctrs r-withr)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('d7f7059bfcb43e4b92432d69ba0e0c74ad10a20f153689262a3e848adb60159d')
+sha256sums=('c6635519503e0fcdd518696d3ac96d8d28d9d4ecd9db0532c53426002f6387b8')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-sass/.SRCINFO
+++ b/packages/r-sass/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-sass
 	pkgdesc = Syntactically Awesome Style Sheets ('Sass')
-	pkgver = 0.4.5
+	pkgver = 0.4.6
 	pkgrel = 1
 	url = https://cran.r-project.org/package=sass
 	arch = i686
@@ -19,7 +19,7 @@ pkgbase = r-sass
 	optdepends = r-withr
 	optdepends = r-shiny
 	optdepends = r-curl
-	source = https://cran.r-project.org/src/contrib/sass_0.4.5.tar.gz
-	sha256sums = eba161d982d2db108c8c0b61ec6b41a20d3adec430c7cc39537ab388c1007a90
+	source = https://cran.r-project.org/src/contrib/sass_0.4.6.tar.gz
+	sha256sums = 2ee82ce709b7fdee78f7e2364d04f369f58fc2cda4bb5a235bd53c49d311c019
 
 pkgname = r-sass

--- a/packages/r-sass/PKGBUILD
+++ b/packages/r-sass/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Viktor Drobot (aka dviktor) linux776 [at] gmail [dot] com
 
 _cranname=sass
-_cranver=0.4.5
+_cranver=0.4.6
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -13,7 +13,7 @@ depends=(r r-fs 'r-rlang>=0.4.10' 'r-htmltools>=0.5.1' r-r6 r-rappdirs)
 makedepends=(make)
 optdepends=(r-testthat r-knitr r-rmarkdown r-withr r-shiny r-curl)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('eba161d982d2db108c8c0b61ec6b41a20d3adec430c7cc39537ab388c1007a90')
+sha256sums=('2ee82ce709b7fdee78f7e2364d04f369f58fc2cda4bb5a235bd53c49d311c019')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-tinytex/.SRCINFO
+++ b/packages/r-tinytex/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-tinytex
 	pkgdesc = Helper Functions to Install and Maintain TeX Live, and Compile LaTeX Documents
-	pkgver = 0.44
+	pkgver = 0.45
 	pkgrel = 1
 	url = https://cran.r-project.org/package=tinytex
 	arch = any
@@ -9,7 +9,7 @@ pkgbase = r-tinytex
 	depends = r-xfun>=0.29
 	optdepends = r-testit
 	optdepends = r-rstudioapi
-	source = https://cran.r-project.org/src/contrib/tinytex_0.44.tar.gz
-	sha256sums = afa14c1274593f0f980b12c4a27b5d0f6cad0c28ed9b4062d59e42562a33620e
+	source = https://cran.r-project.org/src/contrib/tinytex_0.45.tar.gz
+	sha256sums = 0c2fbbd09e80af80ca6b685bf0653f070da97b85413d39af966aba28f376e92c
 
 pkgname = r-tinytex

--- a/packages/r-tinytex/PKGBUILD
+++ b/packages/r-tinytex/PKGBUILD
@@ -5,7 +5,7 @@
 # Contributor: Alex Branham <branham@utexas.edu>
 
 _cranname=tinytex
-_cranver=0.44
+_cranver=0.45
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -16,7 +16,7 @@ license=(MIT)
 depends=(r 'r-xfun>=0.29')
 optdepends=(r-testit r-rstudioapi)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('afa14c1274593f0f980b12c4a27b5d0f6cad0c28ed9b4062d59e42562a33620e')
+sha256sums=('0c2fbbd09e80af80ca6b685bf0653f070da97b85413d39af966aba28f376e92c')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-vctrs/.SRCINFO
+++ b/packages/r-vctrs/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-vctrs
 	pkgdesc = Vector Helpers
-	pkgver = 0.5.2
+	pkgver = 0.6.3
 	pkgrel = 1
 	url = https://cran.r-project.org/package=vctrs
 	arch = i686
@@ -10,7 +10,7 @@ pkgbase = r-vctrs
 	depends = r-cli>=3.4.0
 	depends = r-glue
 	depends = r-lifecycle>=1.0.3
-	depends = r-rlang>=1.0.6
+	depends = r-rlang>=1.1.0
 	optdepends = r-bit64
 	optdepends = r-covr
 	optdepends = r-crayon
@@ -26,7 +26,7 @@ pkgbase = r-vctrs
 	optdepends = r-xml2
 	optdepends = r-waldo
 	optdepends = r-zeallot
-	source = https://cran.r-project.org/src/contrib/vctrs_0.5.2.tar.gz
-	sha256sums = 76bf10243b9b31e23f56ffdaa1677a01767699e2098487f86bd42cb801d8c047
+	source = https://cran.r-project.org/src/contrib/vctrs_0.6.3.tar.gz
+	sha256sums = 93dc220dcde8b440586b2260460ef354e827a17dfec1ea6a9815585a10cfa5c2
 
 pkgname = r-vctrs

--- a/packages/r-vctrs/PKGBUILD
+++ b/packages/r-vctrs/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Grey Christoforo <first name at last name dot net>
 
 _cranname=vctrs
-_cranver=0.5.2
+_cranver=0.6.3
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -10,10 +10,10 @@ pkgdesc="Vector Helpers"
 arch=(i686 x86_64)
 url="https://cran.r-project.org/package=${_cranname}"
 license=(MIT)
-depends=('r>=3.3' 'r-cli>=3.4.0' r-glue 'r-lifecycle>=1.0.3' 'r-rlang>=1.0.6')
+depends=('r>=3.3' 'r-cli>=3.4.0' r-glue 'r-lifecycle>=1.0.3' 'r-rlang>=1.1.0')
 optdepends=(r-bit64 r-covr r-crayon r-dplyr r-generics r-knitr r-pillar r-pkgdown r-rmarkdown r-testthat r-tibble r-withr r-xml2 r-waldo r-zeallot)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('76bf10243b9b31e23f56ffdaa1677a01767699e2098487f86bd42cb801d8c047')
+sha256sums=('93dc220dcde8b440586b2260460ef354e827a17dfec1ea6a9815585a10cfa5c2')
 
 build() {
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"

--- a/packages/r-xfun/.SRCINFO
+++ b/packages/r-xfun/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = r-xfun
 	pkgdesc = Supporting Functions for Packages Maintained by "Yihui Xie"
-	pkgver = 0.37
+	pkgver = 0.39
 	pkgrel = 1
 	url = https://cran.r-project.org/package=xfun
 	arch = i686
@@ -22,7 +22,7 @@ pkgbase = r-xfun
 	optdepends = r-jsonlite
 	optdepends = r-magick
 	optdepends = r-rmarkdown
-	source = https://cran.r-project.org/src/contrib/xfun_0.37.tar.gz
-	sha256sums = 3b619ff0b2aea36a1d422d1f7ca2e5cef0102e1d127c94c87acf5e6e8358e1f9
+	source = https://cran.r-project.org/src/contrib/xfun_0.39.tar.gz
+	sha256sums = d0ecaabb243dd3496da6029932fcdd4772914843de7ffd0b78a172efde1356c9
 
 pkgname = r-xfun

--- a/packages/r-xfun/PKGBUILD
+++ b/packages/r-xfun/PKGBUILD
@@ -1,7 +1,7 @@
 # Contributor: Viktor Drobot (aka dviktor) linux776 [at] gmail [dot] com
 
 _cranname=xfun
-_cranver=0.37
+_cranver=0.39
 pkgname=r-${_cranname,,}
 pkgver=${_cranver//[:-]/.}
 pkgrel=1
@@ -12,7 +12,7 @@ license=(MIT)
 depends=(r)
 optdepends=(r-testit r-rstudioapi r-tinytex r-mime r-markdown r-knitr r-htmltools r-remotes r-pak r-rhub r-renv r-curl r-jsonlite r-magick r-rmarkdown)
 source=("https://cran.r-project.org/src/contrib/${_cranname}_${_cranver}.tar.gz")
-sha256sums=('3b619ff0b2aea36a1d422d1f7ca2e5cef0102e1d127c94c87acf5e6e8358e1f9')
+sha256sums=('d0ecaabb243dd3496da6029932fcdd4772914843de7ffd0b78a172efde1356c9')
 
 build(){
   R CMD INSTALL ${_cranname}_${_cranver}.tar.gz -l "${srcdir}"


### PR DESCRIPTION
r-bslib: 0.4.2 -> 0.5.0
r-cachem: 1.0.7 -> 1.0.8
r-cli: 3.6.0 -> 3.6.1
r-evaluate: 0.20 -> 0.21
r-fontawesome: 0.5.0 -> 0.5.1
r-fs: 1.6.1 -> 1.6.2
r-htmltools: 0.5.4 -> 0.5.5
r-jsonlite: 1.8.4 -> 1.8.5
r-knitr: 1.42 -> 1.43
r-rlang: 1.0.6 -> 1.1.1
r-rmarkdown: 2.20 -> 2.22
r-sass: 0.4.5 -> 0.4.6
r-tinytex: 0.44 -> 0.45
r-vctrs: 0.5.2 -> 0.6.3
r-xfun: 0.37 -> 0.39